### PR TITLE
modernize setup with brewfile, defaults and full app list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+.idea/
+Brewfile.lock.json

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,112 @@
+# Brewfile — declarative macOS package manifest.
+# Run with:  brew bundle install --file=Brewfile
+# Re-capture current system with:  brew bundle dump --file=Brewfile --force --describe
+#
+# Edit freely: comment out anything you don't want on a fresh machine.
+
+# ---------------------------------------------------------------------------
+# Taps
+# ---------------------------------------------------------------------------
+tap "homebrew/bundle"
+tap "mongodb/brew"
+tap "supabase/tap"
+tap "microsoft/mssql-release"
+
+# ---------------------------------------------------------------------------
+# CLI tools (formulae) — development
+# ---------------------------------------------------------------------------
+brew "git"                 # version control
+brew "git-lfs"             # large file storage for git
+brew "gh"                  # GitHub CLI
+brew "bfg"                 # fast git history cleaner (remove secrets/large files)
+brew "subversion"          # svn (WordPress.org plugin SVN, etc.)
+brew "mas"                 # Mac App Store CLI (needed for the `mas` entries below)
+
+# Languages & runtimes
+brew "node@20"             # Node.js
+brew "php@8.1"             # PHP 8.1
+brew "php@8.2"             # PHP 8.2
+brew "composer"            # PHP dependency manager
+
+# Databases
+brew "mysql"               # MySQL server + client
+brew "mongosh"             # MongoDB shell
+brew "mongodb-community", restart_service: false  # MongoDB server (via mongodb/brew tap)
+
+# Content / media tooling
+brew "hugo"                # static site generator
+brew "pandoc"             # document converter
+brew "ffmpeg"              # audio/video processing
+brew "poppler"             # PDF utilities
+brew "librsvg"             # SVG rasterizer (rsvg-convert)
+brew "pngquant"            # PNG lossy compression
+brew "oxipng"              # PNG lossless optimization
+brew "jq"                  # JSON processor
+brew "ripgrep"             # fast recursive search (rg)
+
+# AI / local LLM
+brew "ollama"              # local LLM runtime
+
+# Shell / system
+brew "powerlevel10k"       # zsh prompt theme
+brew "sleepwatcher"        # run scripts on sleep/wake
+
+# Personal / custom
+brew "mole"                # mac cleanup/optimization utility
+# brew "rtk"               # custom LLM token-optimization proxy (private tap — add tap before enabling)
+
+# ---------------------------------------------------------------------------
+# Recommended modern CLI tools (not yet installed — uncomment to adopt)
+# ---------------------------------------------------------------------------
+# brew "eza"               # modern ls (icons, git, tree)
+# brew "bat"               # modern cat (syntax highlighting)
+# brew "fd"                # modern find
+# brew "fzf"               # fuzzy finder
+# brew "zoxide"            # smarter cd (z)
+# brew "lazygit"           # git TUI
+# brew "btop"              # modern top/htop
+# brew "tldr"              # simplified man pages
+
+# ---------------------------------------------------------------------------
+# GUI apps (casks) — development & work
+# ---------------------------------------------------------------------------
+cask "raycast"             # launcher / productivity
+cask "iterm2"              # terminal emulator
+cask "visual-studio-code"  # editor
+cask "jetbrains-toolbox"   # manages PhpStorm / PyCharm / Rider / Fleet
+cask "docker"              # containers
+cask "postman"             # API client
+cask "tableplus"           # database GUI
+cask "mongodb-compass"     # MongoDB GUI
+cask "obsidian"            # notes / knowledge base
+cask "shottr"              # screenshot + annotation
+cask "xampp"               # local Apache/MySQL/PHP stack
+cask "dotnet-sdk"          # .NET SDK
+cask "claude"              # Claude desktop
+
+# Fonts
+cask "font-meslo-lg-nerd-font"  # Nerd Font for Powerlevel10k
+
+# ---------------------------------------------------------------------------
+# GUI apps (casks) — personal / everyday (comment out on work machines)
+# ---------------------------------------------------------------------------
+cask "google-chrome"
+cask "slack"
+cask "spotify"
+cask "whatsapp"
+cask "anydesk"             # remote desktop
+cask "openvpn-connect"     # VPN client
+
+# ---------------------------------------------------------------------------
+# Mac App Store apps (require `mas` + being signed into the App Store)
+# ---------------------------------------------------------------------------
+mas "Keynote", id: 361285480
+mas "Numbers", id: 361304891
+mas "Pages", id: 361309726
+mas "iMovie", id: 408981434
+mas "GarageBand", id: 682658836
+mas "Microsoft Excel", id: 462058435
+mas "Microsoft Outlook", id: 985367838
+mas "MorningPages", id: 1223874080
+mas "Windows App", id: 1295203466
+mas "Hidden Bar", id: 1452453066

--- a/README.md
+++ b/README.md
@@ -1,29 +1,68 @@
 # macOS Setup
 
+Personal macOS bootstrap: one command to set up a fresh Mac with my tools, apps, and system preferences. Declarative (Brewfile) and idempotent (safe to re-run).
+
+## What's inside
+
+| File | Purpose |
+|------|---------|
+| `install.sh` | Orchestrator: Xcode CLT → Rosetta → Homebrew → `brew bundle` → defaults |
+| `Brewfile` | Declarative list of formulae, casks, taps, fonts and Mac App Store apps |
+| `defaults.sh` | Opinionated macOS system preferences (keyboard, Finder, Dock, screenshots) |
+
 ## Installation
 
 ```bash
 git clone git@github.com:kadirermantr/macos-setup.git
 cd macos-setup
 chmod +x install.sh
-bash install.sh
+./install.sh
 ```
 
-## Tools
+Re-running is safe. Already-installed items are skipped.
 
-- [Homebrew](https://brew.sh/) ~ package manager
-- [iTerm2](https://iterm2.com/) ~ terminal emulator
-- [Fig](https://fig.io/) ~ command line
-- [Raycast](https://www.raycast.com/) ~ launcher
-- [XCode](https://developer.apple.com/xcode/)
+> Sign in to the **Mac App Store** first so the `mas` apps install.
 
-## Packages
+## What gets installed
 
-- [php](https://formulae.brew.sh/formula/php)
-- [brew-php-switcher](https://formulae.brew.sh/formula/brew-php-switcher)
-- [mysql](https://formulae.brew.sh/formula/mysql)
-- [redis](https://formulae.brew.sh/formula/redis)
-- [node](https://formulae.brew.sh/formula/node)
-- [nvm](https://formulae.brew.sh/formula/nvm)
-- [git](https://formulae.brew.sh/formula/git)
-- [composer](https://formulae.brew.sh/formula/composer)
+Everything is declared in `Brewfile` — open it to see (and comment out) anything you don't want. Highlights:
+
+- **Dev CLIs:** git, gh, git-lfs, svn, bfg, jq, ripgrep, mas
+- **Languages/runtimes:** node@20, php@8.1, php@8.2, composer
+- **Databases:** mysql, mongosh, mongodb-community
+- **Media/content:** hugo, pandoc, ffmpeg, poppler, librsvg, pngquant, oxipng
+- **AI:** ollama
+- **Shell:** powerlevel10k, sleepwatcher, MesloLGS Nerd Font
+- **GUI (dev):** Raycast, iTerm2, VS Code, JetBrains Toolbox, Docker, Postman, TablePlus, MongoDB Compass, Obsidian, Shottr, XAMPP, .NET SDK, Claude
+- **GUI (personal):** Chrome, Slack, Spotify, WhatsApp, AnyDesk, OpenVPN
+- **App Store:** Keynote, Numbers, Pages, iMovie, GarageBand, Excel, Outlook, MorningPages, Windows App, Hidden Bar
+
+A set of recommended-but-not-yet-installed modern CLIs (eza, bat, fd, fzf, zoxide, lazygit, btop, tldr) is included as commented lines — uncomment to adopt.
+
+## macOS defaults
+
+`defaults.sh` applies sensible, user-level (no `sudo`) preferences: fast key repeat, press-and-hold disabled, Finder showing hidden files / extensions / path bar, no `.DS_Store` on network/USB, Dock autohide, and screenshots saved to `~/Screenshots` as PNG. Dock/Finder restart automatically.
+
+Run it standalone any time:
+
+```bash
+./defaults.sh
+```
+
+## Keeping the Brewfile in sync
+
+After installing or removing things by hand, re-capture the current system:
+
+```bash
+brew bundle dump --file=Brewfile --force --describe
+```
+
+Then review the diff and keep what you want (the file is organized into sections; a raw dump is flat).
+
+## Post-install
+
+- Add Powerlevel10k to `~/.zshrc`:
+  `source "$(brew --prefix)/share/powerlevel10k/powerlevel10k.zsh-theme"` then run `p10k configure`.
+- Select the **MesloLGS NF** font in iTerm2 / your terminal.
+- Sign in to JetBrains Toolbox and install the IDEs you use (PhpStorm, PyCharm, Rider, Fleet).
+- Configure Raycast hotkeys and extensions.

--- a/defaults.sh
+++ b/defaults.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# defaults.sh — opinionated macOS system preferences.
+# All commands are user-level (no sudo). Safe to re-run.
+#
+set -euo pipefail
+
+echo "Applying macOS defaults..."
+
+# ---------------------------------------------------------------------------
+# Keyboard
+# ---------------------------------------------------------------------------
+# Fast key repeat and short delay (great for coding; lower = faster).
+defaults write NSGlobalDomain KeyRepeat -int 2
+defaults write NSGlobalDomain InitialKeyRepeat -int 15
+# Disable press-and-hold accent popup so key repeat works everywhere.
+defaults write NSGlobalDomain ApplePressAndHoldEnabled -bool false
+
+# ---------------------------------------------------------------------------
+# Finder
+# ---------------------------------------------------------------------------
+# Show hidden files, all extensions, path bar and status bar.
+defaults write com.apple.finder AppleShowAllFiles -bool true
+defaults write NSGlobalDomain AppleShowAllExtensions -bool true
+defaults write com.apple.finder ShowPathbar -bool true
+defaults write com.apple.finder ShowStatusBar -bool true
+# Search the current folder by default (not the whole Mac).
+defaults write com.apple.finder FXDefaultSearchScope -string "SCcf"
+# Don't write .DS_Store files on network or USB volumes.
+defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true
+defaults write com.apple.desktopservices DSDontWriteUSBStores -bool true
+
+# ---------------------------------------------------------------------------
+# Dock
+# ---------------------------------------------------------------------------
+defaults write com.apple.dock autohide -bool true
+defaults write com.apple.dock autohide-delay -float 0
+defaults write com.apple.dock tilesize -int 48
+defaults write com.apple.dock show-recents -bool false
+
+# ---------------------------------------------------------------------------
+# Screenshots
+# ---------------------------------------------------------------------------
+# Save screenshots to ~/Screenshots as PNG without the drop shadow.
+mkdir -p "${HOME}/Screenshots"
+defaults write com.apple.screencapture location -string "${HOME}/Screenshots"
+defaults write com.apple.screencapture type -string "png"
+defaults write com.apple.screencapture disable-shadow -bool true
+
+# ---------------------------------------------------------------------------
+# Apply changes
+# ---------------------------------------------------------------------------
+killall Dock 2>/dev/null || true
+killall Finder 2>/dev/null || true
+killall SystemUIServer 2>/dev/null || true
+
+echo "macOS defaults applied. Some changes may require a logout/restart."

--- a/install.sh
+++ b/install.sh
@@ -1,57 +1,95 @@
 #!/bin/bash
+#
+# install.sh — bootstrap a macOS machine.
+#
+# Order matters: Xcode CLT -> Rosetta -> Homebrew -> shellenv -> Brewfile -> defaults.
+# Safe to re-run (idempotent).
+#
+set -euo pipefail
 
-tools=(
-  iterm2
-  fig
-  raycast
-)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-packages=(
-  php
-  brew-php-switcher
-  mysql
-  redis
-  node
-  nvm
-  git
-  composer
-)
+# ---------------------------------------------------------------------------
+# Logging helpers
+# ---------------------------------------------------------------------------
+BLUE='\033[0;34m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'; RED='\033[0;31m'; NC='\033[0m'
+log_info()    { echo -e "${BLUE}==>${NC} $1"; }
+log_success() { echo -e "${GREEN}✓${NC} $1"; }
+log_warn()    { echo -e "${YELLOW}!${NC} $1"; }
+log_error()   { echo -e "${RED}✗${NC} $1" >&2; }
 
-# Install the Homebrew
-if test ! "$(which brew)"; then
-  echo "Installing Homebrew..."
-  ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+# ---------------------------------------------------------------------------
+# 1. Xcode Command Line Tools
+# ---------------------------------------------------------------------------
+if xcode-select -p >/dev/null 2>&1; then
+  log_success "Xcode Command Line Tools already installed."
+else
+  log_info "Installing Xcode Command Line Tools..."
+  xcode-select --install
+  log_warn "Finish the CLT installer dialog, then re-run this script."
+  exit 1
 fi
 
-# Update Homebrew
-echo "Updating Homebrew..."
+# ---------------------------------------------------------------------------
+# 2. Rosetta 2 (Apple Silicon only)
+# ---------------------------------------------------------------------------
+if [ "$(uname -m)" = "arm64" ]; then
+  if /usr/bin/pgrep -q oahd; then
+    log_success "Rosetta 2 already installed."
+  else
+    log_info "Installing Rosetta 2..."
+    softwareupdate --install-rosetta --agree-to-license || log_warn "Rosetta install skipped/failed."
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Homebrew
+# ---------------------------------------------------------------------------
+if ! command -v brew >/dev/null 2>&1; then
+  log_info "Installing Homebrew..."
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+else
+  log_success "Homebrew already installed."
+fi
+
+# Load brew into this shell (Apple Silicon uses /opt/homebrew).
+if [ -x /opt/homebrew/bin/brew ]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -x /usr/local/bin/brew ]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+fi
+
+log_info "Updating Homebrew..."
 brew update
 
-# Install Packages
-echo "Installing Packages..."
-
-for package in "${packages[@]}"; do
-  if brew list "$package" > /dev/null 2>&1; then
-    echo "$package already installed... skipping."
-  else
-    brew install "$package"
-  fi
-done
-
-# Install Tools
-echo "Installing Tools..."
-
-for tool in "${tools[@]}"; do
-  if brew list --cask "$tool" > /dev/null 2>&1; then
-    echo "$tool already installed... skipping."
-  else
-    brew install --cask "$tool"
-  fi
-done
-
-# Install Xcode
-if ! xcode-select -p > /dev/null; then
-  xcode-select --install
+# ---------------------------------------------------------------------------
+# 4. Install everything from the Brewfile
+# ---------------------------------------------------------------------------
+if [ -f "${SCRIPT_DIR}/Brewfile" ]; then
+  log_info "Installing packages from Brewfile..."
+  # --no-lock avoids writing a Brewfile.lock.json; remove if you want a lockfile.
+  brew bundle install --file="${SCRIPT_DIR}/Brewfile" || log_warn "Some Brewfile entries failed; continuing."
+  log_success "Brewfile processed."
 else
-  echo "Xcode already installed... skipping."
+  log_error "Brewfile not found next to install.sh."
+  exit 1
 fi
+
+# ---------------------------------------------------------------------------
+# 5. macOS defaults
+# ---------------------------------------------------------------------------
+if [ -f "${SCRIPT_DIR}/defaults.sh" ]; then
+  log_info "Applying macOS defaults..."
+  bash "${SCRIPT_DIR}/defaults.sh" || log_warn "Some defaults failed to apply."
+fi
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+log_success "Bootstrap complete."
+echo
+log_info "Manual follow-ups:"
+echo "  • Sign in to the Mac App Store before re-running for 'mas' apps."
+echo "  • Set Powerlevel10k: add 'source \$(brew --prefix)/share/powerlevel10k/powerlevel10k.zsh-theme' to ~/.zshrc, then run 'p10k configure'."
+echo "  • Set the MesloLGS NF font in your terminal."
+echo "  • Configure Raycast, iTerm2 and JetBrains Toolbox sign-in manually."


### PR DESCRIPTION
Rebuild the old minimal install script into a declarative, idempotent setup.

- Brewfile: taps, formulae, casks (dev + personal), fonts, and Mac App Store apps captured from the current machine
- defaults.sh: user-level macOS preferences (keyboard, Finder, Dock, screenshots)
- install.sh: robust orchestrator (Xcode CLT, Rosetta, Homebrew, brew bundle, defaults) with set -euo pipefail and logging
- README rewritten; .gitignore added
- Dropped fig (discontinued) and textream